### PR TITLE
feat: push0 support in Arbitrum

### DIFF
--- a/src/docs/arbitrum-one.mdx
+++ b/src/docs/arbitrum-one.mdx
@@ -133,9 +133,11 @@ links:
     | Address | Name | Description |
     | :--- | :--- | :--- |
     | <Copy value="0x6d" label="0x6d" /> | <Reference label="ArbAggregator" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbAggregator.go" /> | Provides aggregators and their user's methods for configuring how they participate in L1 aggregation. Arbitrum One's default aggregator is the Sequencer, which a user will prefer unless `SetPreferredAggregator` is invoked to change it.|
-    | <Copy value="0x6c" label="0x6c" /> | <Reference label="ArbGasInfo" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbGasInfo.go" /> | Provides data for gas costs in wei and ArbGas, estimates for L1 basefee as-well as information on the chain speed limit, pool size and transaction gas limit.|
+    | <Copy value="0x6c" label="0x6c" /> | <Reference label="ArbGasInfo" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbGasInfo.go" /> | Provides data for gas costs in wei and ArbGas, estimates for L1 basefee, the L1 pricer reward rate and recipient as-well as information on the chain speed limit, pool size and transaction gas limit.|
     | <Copy value="0x6e" label="0x6e" /> | <Reference label="ArbRetryableTx" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbRetryableTx.go" /> | Provides methods for managing retryables (cross domain messages). [Retryable documentation](https://developer.arbitrum.io/arbos/l1-to-l2-messaging).|
     | <Copy value="0x64" label="0x64" /> | <Reference label="ArbSys" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbSys.go" /> | Provides system-level functionality for getting L2 block number, hash, checking if a call is top-level, sending cross-domain messages as-well as sending ETH to L1.|
+    | <Copy value="0x65" label="0x65" /> | <Reference label="ArbInfo" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbInfo.go" /> | Provides the ability to lookup account's balance and contract's deployed code.|
+    | <Copy value="0x6b" label="0x6b" /> | <Reference label="ArbOwnerPublic" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbOwnerPublic.go" /> | Provides non-owners with info about the current chain owners.|
 
 </Section>
 

--- a/src/docs/arbitrum-one.mdx
+++ b/src/docs/arbitrum-one.mdx
@@ -111,7 +111,6 @@ links:
 
     | Opcode | Name | Solidity Equivalent | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :--- | :-------------------| :--------------- | :-------------------- |
-    | 5F | PUSH0 |  | Not supported yet! <br /><br /> Solidity version `0.8.20` or higher can only be used with an evm version lower than the default `shanghai`. <br /><br /> Versions up to `0.8.19` (included) are fully compatible | Places value 0 on the stack <Unsupported /> |
     | 33 | CALLER | `msg.sender` | Same behaviour as on Ethereum for L2 to L2 transactions <br /><br /> Returns the L2 address alias of the L1 contract that triggered the message for L1-to-L2 "retryable ticket" transactions. See [retryable ticket address aliasing](https://developer.arbitrum.io/arbos/l1-to-l2-messaging#address-aliasing) for more. | Returns caller address <Modified /> |
     | 40 | BLOCKHASH | `blockhash(x)` | Returns a cryptographically insecure, pseudo-random hash for `x` within the range `block.number - 256 <= x < block.number`. <br /><br /> If `x` is outside of this range, `blockhash(x)` will return 0. This includes `blockhash(block.number)`, which always returns `0` just like on Ethereum. <br /><br /> The hashes returned do not come from L1. | Returns the hash of one of the 256 most recent complete blocks <Modified /> |
     | 41 | COINBASE | `block.coinbase` | Returns `0` | Returns the L1 block’s beneficiary address <Modified /> |


### PR DESCRIPTION
With [ArbOS version 11](https://forum.arbitrum.foundation/t/aip-arbos-version-11/19696), Arbitrum now supports the Shanghai L1 upgrade, which includes the PUSH0 OPCODE