### PR TITLE
Feat: change finality wording

### DIFF
--- a/src/components/MDXShortcodes/index.tsx
+++ b/src/components/MDXShortcodes/index.tsx
@@ -58,7 +58,7 @@ const Copy = ({ value, label }: { value: string; label: string }) => {
     }, [copied])
 
     return (
-        <div className={styles.copy}>
+        <div className={styles.copy} title={value}>
             {label && label}
             <CopyToClipboard text={value} onCopy={() => setCopied(true)}>
                     <span className={styles.copyIcon}>

--- a/src/docs/arbitrum-one.mdx
+++ b/src/docs/arbitrum-one.mdx
@@ -47,7 +47,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="30 - 120 seconds" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1" />
 
-    <Parameter name="Objective Finality" value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
+    <Parameter name="Objective Finality" value="7 days" tooltip="The time it takes for the L2 to reach objective finality. Objective Finality is the state after which actors following only the L1 can conclude that a given state is finalised" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6" url="https://etherscan.io/address/0x1c479675ad559dc151f6ec7ed3fbf8cee79582b6" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/arbitrum-one.mdx
+++ b/src/docs/arbitrum-one.mdx
@@ -47,7 +47,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="30 - 120 seconds" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1" />
 
-    <Parameter name="Finality" value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
+    <Parameter name="Objective Finality" value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6" url="https://etherscan.io/address/0x1c479675ad559dc151f6ec7ed3fbf8cee79582b6" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/base.mdx
+++ b/src/docs/base.mdx
@@ -46,7 +46,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="0.5 - 2 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. The time varies based on the amount of calldata that must be posted on L1" />
 
-    <Parameter name="Finality" value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
+    <Parameter name="Objective Finality" value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0x56315b90c40730925ec5485cf004d835058518A0" url="https://etherscan.io/address/0x56315b90c40730925ec5485cf004d835058518A0" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/base.mdx
+++ b/src/docs/base.mdx
@@ -46,7 +46,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="0.5 - 2 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. The time varies based on the amount of calldata that must be posted on L1" />
 
-    <Parameter name="Objective Finality" value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
+    <Parameter name="Objective Finality" value="7 days" tooltip="The time it takes for the L2 to reach objective finality. Objective Finality is the state after which actors following only the L1 can conclude that a given state is finalised" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0x56315b90c40730925ec5485cf004d835058518A0" url="https://etherscan.io/address/0x56315b90c40730925ec5485cf004d835058518A0" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/linea.mdx
+++ b/src/docs/linea.mdx
@@ -45,7 +45,7 @@ Linea is a ZK-Rollup that targets EVM compatibility. The protocol team centrally
 
     <Parameter name="Sequencing Frequency" value="30 - 120 seconds" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1." />
 
-    <Parameter name="Finality" value="8 - 32 hours" tooltip="The time it takes for validity proof to be generated and submitted which makes an L2 transaction final. ZK proof generation takes around 15 minutes, but its submission is delayed by at least 8 hours as a security measure during the alpha phase. The protocol may delay the submission up to 32 hours in order to minimize the L1 gas cost." />
+    <Parameter name="Objective Finality" value="8 - 32 hours" tooltip="The time it takes for validity proof to be generated and submitted which makes an L2 transaction final. ZK proof generation takes around 15 minutes, but its submission is delayed by at least 8 hours as a security measure during the alpha phase. The protocol may delay the submission up to 32 hours in order to minimize the L1 gas cost." />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0xd19d4B5d358258f05D7B411E21A1460D11B0876F" url="https://etherscan.io/address/0xd19d4B5d358258f05D7B411E21A1460D11B0876F" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/optimism.mdx
+++ b/src/docs/optimism.mdx
@@ -45,7 +45,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="0.5 - 2 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. The time varies based on the amount of calldata that must be posted on L1" />
 
-    <Parameter name="Objective Finality"  value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
+    <Parameter name="Objective Finality"  value="7 days" tooltip="The time it takes for the L2 to reach objective finality. Objective Finality is the state after which actors following only the L1 can conclude that a given state is finalised" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0xdfe97868233d1aa22e815a266982f2cf17685a27" url="https://etherscan.io/address/0xdfe97868233d1aa22e815a266982f2cf17685a27" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/optimism.mdx
+++ b/src/docs/optimism.mdx
@@ -45,7 +45,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="0.5 - 2 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. The time varies based on the amount of calldata that must be posted on L1" />
 
-    <Parameter name="Finality"  value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
+    <Parameter name="Objective Finality"  value="7 days" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0xdfe97868233d1aa22e815a266982f2cf17685a27" url="https://etherscan.io/address/0xdfe97868233d1aa22e815a266982f2cf17685a27" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/polygon-zkevm.mdx
+++ b/src/docs/polygon-zkevm.mdx
@@ -46,7 +46,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="~4-8 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. Minutes vary based on the load of the Rollup" />
 
-    <Parameter name="Finality" value="~1 hour" tooltip="The time it takes for validity proof to be generated and submitted which makes an L2 transaction final" />
+    <Parameter name="Objective Finality" value="~1 hour" tooltip="The time it takes for validity proof to be generated and submitted which makes an L2 transaction final" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2" url="https://etherscan.io/address/0x5132a183e9f3cb7c848b0aac5ae0c4f0491b7ab2" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/scroll.mdx
+++ b/src/docs/scroll.mdx
@@ -42,7 +42,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="2 - 45 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. The time varies based on the load of the network. Batches are created and posted once sufficient computation and calldata is produced. The protocol enforces a maximum delay at which batches are posted even though the targets for computation and calldata are not reached. " />
 
-    <Parameter name="Finality"  value="< 30 minutes" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
+    <Parameter name="Objective Finality"  value="< 30 minutes" tooltip="The time it takes for an L2 transaction to be considered final after it is sequenced on L1" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0xa13BAF47339d63B743e7Da8741db5456DAc1E556" url="https://etherscan.io/address/0xa13baf47339d63b743e7da8741db5456dac1e556" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/taiko.mdx
+++ b/src/docs/taiko.mdx
@@ -48,7 +48,7 @@ links:
 
     <Parameter name="Gas Limit" value="8.18 million" tooltip="The gas limit that can be consumed by an L2 block. 180 000 gas is reserved for the anchor transaction."/>
 
-    <Parameter name="Verification" value="~90 minutes" tooltip="The time it takes for a validity proof of an L2 block to be generated and submitted after it is sequenced on L1." />
+    <Parameter name="Objective Finality" value="~90 minutes" tooltip="The time it takes for a validity proof of an L2 block to be generated and submitted after it is sequenced on L1." />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0x95fF8D3CE9dcB7455BEB7845143bEA84Fe5C4F6f" url="https://sepolia.etherscan.io/address/0x95fF8D3CE9dcB7455BEB7845143bEA84Fe5C4F6f" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 

--- a/src/docs/zksync-era.mdx
+++ b/src/docs/zksync-era.mdx
@@ -44,7 +44,7 @@ links:
 
     <Parameter name="Sequencing Frequency" value="~6-15 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. Minutes vary based on the load of the rollup" />
 
-    <Parameter name="Finality" value="24 hours" tooltip="The time it takes for validity proof to be generated and submitted which makes an L2 transaction final. ZK proof generation takes around an hour, but its submission is delayed by ~21 hours as a security measure during the alpha phase" />
+    <Parameter name="Objective Finality" value="24 hours" tooltip="The time it takes for validity proof to be generated and submitted which makes an L2 transaction final. ZK proof generation takes around an hour, but its submission is delayed by ~21 hours as a security measure during the alpha phase" />
 
     <Parameter name="Rollup’s State Contract on L1" value={<Reference label="0x32400084C286CF3E17e7B677ea9583e60a000324" url="https://etherscan.io/address/0x32400084C286CF3E17e7B677ea9583e60a000324" />} tooltip="The contract used for sequencing, proving and storing the state of the L2 network" />
 


### PR DESCRIPTION
Renames the `Finality` parameter to `Objective Finality`. Also adds a title attribute to the `Copy` component in order to show the full system contract/precompile address on hover.