### PR TITLE
feat(Scroll): remove SHA-256 precompile from unsupported

### DIFF
--- a/src/docs/scroll.mdx
+++ b/src/docs/scroll.mdx
@@ -121,7 +121,6 @@ links:
 
     | Address | Name | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :----- | :--------------- | :-------------------- |
-    | <Copy label="0x02" value="0x02" /> | `SHA2-256` | Not supported | Hash function <Unsupported /> |
     | <Copy label="0x03" value="0x03" /> | `RIPEMD-160` | Not supported | Hash function <Unsupported /> |
     | <Copy label="0x05" value="0x05" /> | `modexp` | Supports only inputs of size less than or equal to 32 bytes (i.e. `u256`). | Arbitrary-precision exponentiation under modulo <Modified /> |
     | <Copy label="0x08" value="0x08" /> | `ecPairing` | The number of points(sets, pairs) is limited to 4, instead of 6. | Bilinear function on groups on the elliptic curve 'alt_bn128' <Modified /> |


### PR DESCRIPTION
- removes SHA-256 precompile from unsupported for Scroll
- Fixes #100 