### PR TITLE
feat(taiko): missing rpc api calls

### DIFF
--- a/src/docs/taiko.mdx
+++ b/src/docs/taiko.mdx
@@ -160,7 +160,7 @@ links:
     | `taiko_headL1Origin` | None | Returns the latest L2 block's corresponding L1 origin | N/A <Added /> |
     | `taiko_l1OriginByID` | L2 block number | Returns the L2 block's corresponding L1 origin | N/A <Added /> |
     | `taiko_getSyncMode` | None | Returns the current sync mode of the L2 node. <br /><br />Sync mode can be `full`, `snap` or `light`. | N/A <Added /> |
-    | `taikoAuth_txPoolContent` | beneficiary - `address`, coinbase address <br /> baseFee - `big.Int` <br /> blockMaxGasLimit - `uint32` <br /> maxBytesPerTxList - `uint64` <br /> locals - `[]string`, prioritised transaction senders from the transaction pool <br /> maxTransactionsLists - `uint64` | Retrieves the transaction pool content with the given upper limits. <br/> <br/> Requires JWT authentication. | N/A <Added />
+    | `taikoAuth_txPoolContent` | `beneficiary` - coinbase address <br /> `baseFee` <br /> `blockMaxGasLimit`<br /> `maxBytesPerTxList` <br /> `locals` - a list of prioritised transaction senders from the transaction pool <br /> `maxTransactionsLists` | Returns multiple transaction lists from the transaction pool, which satisfy all the given limits. <br/> <br/> Requires JWT authentication. | N/A <Added />
 
 </Section>
 

--- a/src/docs/taiko.mdx
+++ b/src/docs/taiko.mdx
@@ -159,6 +159,8 @@ links:
     | :----- | :----- | :--------------- | :-------------------- |
     | `taiko_headL1Origin` | None | Returns the latest L2 block's corresponding L1 origin | N/A <Added /> |
     | `taiko_l1OriginByID` | L2 block number | Returns the L2 block's corresponding L1 origin | N/A <Added /> |
+    | `taiko_getSyncMode` | None | Returns the current sync mode of the L2 node. <br /><br />Sync mode can be `full`, `snap` or `light`. | N/A <Added /> |
+    | `taikoAuth_txPoolContent` | beneficiary - `address`, coinbase address <br /> baseFee - `big.Int` <br /> blockMaxGasLimit - `uint32` <br /> maxBytesPerTxList - `uint64` <br /> locals - `[]string`, prioritised transaction senders from the transaction pool <br /> maxTransactionsLists - `uint64` | Retrieves the transaction pool content with the given upper limits. <br/> <br/> Requires JWT authentication. | N/A <Added />
 
 </Section>
 

--- a/src/docs/taiko.mdx
+++ b/src/docs/taiko.mdx
@@ -159,7 +159,7 @@ links:
     | :----- | :----- | :--------------- | :-------------------- |
     | `taiko_headL1Origin` | None | Returns the latest L2 block's corresponding L1 origin | N/A <Added /> |
     | `taiko_l1OriginByID` | L2 block number | Returns the L2 block's corresponding L1 origin | N/A <Added /> |
-    | `taiko_getSyncMode` | None | Returns the current sync mode of the L2 node. <br /><br />Sync mode can be `full`, `snap` or `light`. | N/A <Added /> |
+    | `taiko_getSyncMode` | None | Returns the current sync mode of the L2 node. <br /><br /> Sync mode can be `full`, `snap` or `light`. | N/A <Added /> |
     | `taikoAuth_txPoolContent` | `beneficiary` - coinbase address <br /> `baseFee` <br /> `blockMaxGasLimit`<br /> `maxBytesPerTxList` <br /> `locals` - a list of prioritised transaction senders from the transaction pool <br /> `maxTransactionsLists` | Returns multiple transaction lists from the transaction pool, which satisfy all the given limits. <br/> <br/> Requires JWT authentication. | N/A <Added />
 
 </Section>


### PR DESCRIPTION
Add missing rpc api calls:
* `taiko_getSyncMode` - [link](https://github.com/taikoxyz/taiko-geth/blob/taiko/eth/taiko_api_backend.go#L64)
* `taikoAuth_txPoolContent` - [link](https://github.com/taikoxyz/taiko-geth/blob/taiko/eth/taiko_api_backend.go#L79), beneficial for the whole L2 execution.