### PR TITLE
scroll: add `p256Verify` precompile

### DIFF
--- a/src/docs/scroll.mdx
+++ b/src/docs/scroll.mdx
@@ -123,6 +123,7 @@ links:
     | <Copy label="0x08" value="0x08" /> | `ecPairing` | The number of points(sets, pairs) is limited to 4, instead of 6. | Bilinear function on groups on the elliptic curve 'alt_bn128' <Modified /> |
     | <Copy label="0x09" value="0x09" /> | `blake2f` | Not supported | Compression function F used in the BLAKE2 cryptographic hashing algorithm <Unsupported /> |
     | <Copy label="0x0a" value="0x0a" /> | `pointEvaluation` | Not supported | Verifies a KZG proof <Unsupported /> |
+    | <Copy label="0x100" value="0x100" /> | `p256Verify` | Performs signature verifications in the secp256r1 elliptic curve | Not supported <Added /> |
 
 </Section>
 


### PR DESCRIPTION
scroll already supports `p256Verify`. see https://github.com/scroll-tech/go-ethereum/pull/798