### PR TITLE
fix: add Type-1 transactions in supported transactions

### DIFF
--- a/src/docs/scroll.mdx
+++ b/src/docs/scroll.mdx
@@ -53,6 +53,7 @@ links:
     <Parameter name="Transaction Types" tooltip="The types of transactions supported on the Rollup" />
 
     - **Type 0** - User Transactions. Represent [pre-EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) transactions
+    - **Type 1** - User Transactions. Represent legacy transactions post [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
     - **Type 2** - User Transaction. [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions
     - **Type 126** - User Transactions. Represent custom [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) transaction called `L1MessageTx` Transaction. This type of transaction is used for messaging and bridging from L1 to L2.
 


### PR DESCRIPTION
This PR fixes an info error since Scroll has supported Type-1 transactions.
An example: https://scrollscan.com/tx/0xcccf32b0390ec1a35c94aabab8aecd6e699490c86968927258f4f9a5c7637e7e
![image](https://github.com/user-attachments/assets/d3462e4f-b259-42c4-ade6-891a9f045457)
