### PR TITLE
feat(opstack): update opcodes

### DIFF
--- a/src/docs/base.mdx
+++ b/src/docs/base.mdx
@@ -108,10 +108,7 @@ links:
     | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
-    | 41 | COINBASE | `block.coinbase` | Get the L2 block's beneficiary address | Get the L1 block’s beneficiary address <Modified /> |
-    | 42 | TIMESTAMP | `block.timestamp` | Timestamp of the L2 block | Timestamp of the L1 block <Modified /> |
-    | 43 | NUMBER | `block.number` | L2 block number | Gets the L1 block number <Modified /> |
-    | 44 | DIFFICULTY | `block.difficulty` | Random value. <br /><br /> As this value is set by the sequencer, it is less reliably random than the L1 equivalent. <br /><br /> [You can use an oracle for randomness](https://community.optimism.io/docs/useful-tools/oracles/#verifiable-randomness-function-vrf). | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
+    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the same value as the latest L1 block synced in the L2 state | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
     | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>
@@ -124,7 +121,6 @@ links:
 
     | Address | Name | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :----- | :--------------- | :-------------------- |
-    | <Copy label="0x0a" value="0x0a" /> | `pointEvaluation` | Not supported | Verifies a KZG proof <Unsupported /> |
     | <Copy label="0x100" value="0x100" /> | `p256Verify` | Performs signature verifications in the secp256r1 elliptic curve | Not supported <Added /> |
 
 </Section>

--- a/src/docs/base.mdx
+++ b/src/docs/base.mdx
@@ -108,7 +108,7 @@ links:
     | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
-    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the same value as the latest L1 block synced in the L2 state | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
+    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the randomness beacon provided by the L1 beacon chain of the latest synced L1 state on the L2 | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
     | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>

--- a/src/docs/blast.mdx
+++ b/src/docs/blast.mdx
@@ -107,7 +107,7 @@ links:
     | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
-    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the same value as the latest L1 block synced in the L2 state | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
+    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the randomness beacon provided by the L1 beacon chain of the latest synced L1 state on the L2 | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
     | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>

--- a/src/docs/blast.mdx
+++ b/src/docs/blast.mdx
@@ -107,10 +107,7 @@ links:
     | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
-    | 41 | COINBASE | `block.coinbase` | Get the L2 block's beneficiary address | Get the L1 block’s beneficiary address <Modified /> |
-    | 42 | TIMESTAMP | `block.timestamp` | Timestamp of the L2 block | Timestamp of the L1 block <Modified /> |
-    | 43 | NUMBER | `block.number` | L2 block number | Gets the L1 block number <Modified /> |
-    | 44 | DIFFICULTY | `block.difficulty` | Random value. <br /><br /> As this value is set by the sequencer, it is less reliably random than the L1 equivalent. <br /><br /> [You can use an oracle for randomness](https://community.optimism.io/docs/useful-tools/oracles/#verifiable-randomness-function-vrf). | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
+    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the same value as the latest L1 block synced in the L2 state | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
     | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>

--- a/src/docs/optimism.mdx
+++ b/src/docs/optimism.mdx
@@ -107,7 +107,7 @@ links:
     | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
-    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the same value as the latest L1 block synced in the L2 state | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
+    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the randomness beacon provided by the L1 beacon chain of the latest synced L1 state on the L2 | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
     | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>

--- a/src/docs/optimism.mdx
+++ b/src/docs/optimism.mdx
@@ -19,8 +19,8 @@ links:
         url: https://github.com/ethereum-optimism/optimism
         name: Github
     twitter:
-        url: https://twitter.com/OptimismFND
-        name: optimismFND
+        url: https://x.com/optimism
+        name: optimism
 ---
 
 <Section title="Overview">
@@ -107,10 +107,7 @@ links:
     | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
-    | 41 | COINBASE | `block.coinbase` | Get the L2 block's beneficiary address | Get the L1 block’s beneficiary address <Modified /> |
-    | 42 | TIMESTAMP | `block.timestamp` | Timestamp of the L2 block | Timestamp of the L1 block <Modified /> |
-    | 43 | NUMBER | `block.number` | L2 block number | Gets the L1 block number <Modified /> |
-    | 44 | DIFFICULTY | `block.difficulty` | Random value. <br /><br /> As this value is set by the sequencer, it is less reliably random than the L1 equivalent. <br /><br /> [You can use an oracle for randomness](https://community.optimism.io/docs/useful-tools/oracles/#verifiable-randomness-function-vrf). | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
+    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the same value as the latest L1 block synced in the L2 state | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
     | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>
@@ -123,7 +120,6 @@ links:
 
     | Address | Name | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :----- | :--------------- | :-------------------- |
-    | <Copy label="0x0a" value="0x0a" /> | `pointEvaluation` | Not supported | Verifies a KZG proof <Unsupported /> |
     | <Copy label="0x100" value="0x100" /> | `p256Verify` | Performs signature verifications in the secp256r1 elliptic curve | Not supported <Added /> |
 
 </Section>


### PR DESCRIPTION
- Changes `COINBASE`, `TIMESTAMP` and `NUMBER` to unmodified for `Base`, `Blast` and `Optimism`
- Renames `DIFFICULTY` to `PREVRANDAO` and updates its information for `Base`, `Blast` and `Optimism`
- Changes `pointEvaluation` to supported for `Base` and `Optimism`