### PR TITLE
Feat: zksync precompiles docs

### DIFF
--- a/src/docs/zksync-era.mdx
+++ b/src/docs/zksync-era.mdx
@@ -148,6 +148,8 @@ links:
     | <Copy label="0x0a" value="0x0a" /> | `pointEvaluation` | Not supported | Verifies a KZG proof <Unsupported /> |
     | <Copy label="0x100" value="0x0a" /> | `p256Verify` | Performs signature verifications in the secp256r1 elliptic curve | Not supported <Added /> |
 
+    Additional information on the supported precompiled contracts can be found in [ZKsync Era Docs](https://docs.zksync.io/zksync-protocol/differences/pre-compiles).
+
 </Section>
 
 <Section title="System Contracts">

--- a/src/docs/zksync-era.mdx
+++ b/src/docs/zksync-era.mdx
@@ -148,7 +148,7 @@ links:
     | <Copy label="0x0a" value="0x0a" /> | `pointEvaluation` | Not supported | Verifies a KZG proof <Unsupported /> |
     | <Copy label="0x100" value="0x0a" /> | `p256Verify` | Performs signature verifications in the secp256r1 elliptic curve | Not supported <Added /> |
 
-    Additional information on the supported precompiled contracts can be found in [ZKsync Era Docs](https://docs.zksync.io/zksync-protocol/differences/pre-compiles).
+    Additional information on the supported precompiled contracts can be found in [ZKsync Protocol Docs](https://docs.zksync.io/zksync-protocol/differences/pre-compiles).
 
 </Section>
 


### PR DESCRIPTION
Just adding a minor paragraph with a link to the ZKsync protocol precomiles docs, a new page that we've added recently and that can be helpful so see not just the unsupported precompiles but the supported ones.