### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,29 +11,27 @@
         "format:fix": "prettier --write --ignore-path .gitignore ."
     },
     "dependencies": {
-        "@types/node": "20.3.0",
-        "@types/react": "18.2.24",
-        "@types/react-dom": "18.2.4",
-        "classnames": "^2.3.2",
-        "date-fns": "^2.30.0",
-        "eslint": "8.42.0",
-        "eslint-config-next": "13.4.5",
+        "classnames": "^2.5.1",
+        "date-fns": "^4.1.0",
+        "eslint": "9.22.0",
+        "eslint-config-next": "15.2.1",
         "gray-matter": "^4.0.3",
-        "next": "13.4.5",
-        "next-mdx-remote": "^4.4.1",
-        "next-themes": "^0.2.1",
-        "react": "18.2.0",
-        "react-copy-to-clipboard": "^5.1.0",
-        "react-dom": "18.2.0",
-        "react-tooltip": "^5.14.0",
-        "remark-gfm": "^3.0.1",
-        "typescript": "5.1.3"
+        "next": "^15.2.1",
+        "next-mdx-remote": "^5.0.0",
+        "next-themes": "^0.4.5",
+        "react": "19.0.0",
+        "react-dom": "19.0.0",
+        "react-tooltip": "^5.28.0",
+        "remark-gfm": "^4.0.1",
+        "typescript": "5.8.2"
     },
     "devDependencies": {
-        "@svgr/webpack": "^8.0.1",
-        "@types/react-copy-to-clipboard": "^5.0.4",
+        "@svgr/webpack": "^8.1.0",
+        "@types/node": "22.13.10",
+        "@types/react": "19.0.10",
+        "@types/react-dom": "19.0.4",
         "path": "^0.12.7",
-        "prettier": "^2.8.8",
-        "sass": "^1.63.3"
+        "prettier": "^3.5.3",
+        "sass": "^1.85.1"
     }
 }

--- a/src/components/Breadcrumbs/styles.module.scss
+++ b/src/components/Breadcrumbs/styles.module.scss
@@ -1,8 +1,8 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 .breadcrumbs {
     display: none;
-    @include tablet {
+    @include mixins.tablet {
         display: flex;
         flex-direction: row;
         align-items: center;

--- a/src/components/Container/styles.module.scss
+++ b/src/components/Container/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 .container {
     max-width: 1920px;
@@ -8,7 +8,7 @@
     flex: 1;
     flex-direction: column;
     padding: 0 16px;
-    @include tablet {
+    @include mixins.tablet {
         padding: 0 64px;
     }
 }

--- a/src/components/Footer/styles.module.scss
+++ b/src/components/Footer/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 .footer {
     display: flex;
@@ -7,7 +7,7 @@
     align-items: center;
     row-gap: 16px;
     padding: 10px 0;
-    @include desktop {
+    @include mixins.desktop {
         flex-direction: row;
     }
 }
@@ -18,14 +18,14 @@
     align-items: center;
     padding: 6px 0;
     row-gap: 24px;
-    @include desktop {
+    @include mixins.desktop {
         flex-direction: row;
     }
 }
 
 .pipe {
     display: none;
-    @include desktop {
+    @include mixins.desktop {
         display: flex;
         margin: 0 16px;
     }

--- a/src/components/Grid/styles.module.scss
+++ b/src/components/Grid/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 .grid {
     display: flex;
@@ -7,7 +7,7 @@
     column-gap: 16px;
     padding-bottom: 64px;
     justify-content: flex-start;
-    @include tablet {
+    @include mixins.tablet {
         flex-direction: row;
         flex-wrap: wrap;
     }

--- a/src/components/Hero/styles.module.scss
+++ b/src/components/Hero/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 .hero {
     display: flex;
@@ -19,7 +19,7 @@
         bottom: 0;
         left: 0;
     }
-    @include tablet {
+    @include mixins.tablet {
         max-width: 1920px - 128px;
     }
 }
@@ -35,7 +35,7 @@
     justify-content: center;
     transition: background .3s ease;
     padding: 0 16px;
-    @include tablet {
+    @include mixins.tablet {
         padding: 0 64px;
     }
 }

--- a/src/components/MDXShortcodes/index.tsx
+++ b/src/components/MDXShortcodes/index.tsx
@@ -10,7 +10,6 @@ import UnsupportedIcon from '/public/images/unsupported-triangle-icon.svg'
 import ModifiedIcon from '/public/images/modified-triangle-icon.svg'
 import AddedIcon from '/public/images/added-triangle-icon.svg'
 import CopyIcon from '/public/images/copy-icon.svg'
-import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import ReferenceIcon from '/public/images/reference-icon.svg'
@@ -28,12 +27,12 @@ const Tooltip = ({ tooltip }: { tooltip: string }) => {
             <QuestionMarkIcon />
             <TooltipComponent
                 id={`${id}-tooltip`}
+                opacity={1}
                 style={{
                     background: 'var(--opposite-background-color)',
                     color: 'var(--opposite-text-color)',
                     zIndex: 1,
                     borderRadius: 0,
-                    opacity: 1,
                     maxWidth: 200,
                     height: 'auto',
                     fontWeight: '400',
@@ -57,11 +56,12 @@ const Copy = ({ value, label }: { value: string; label: string }) => {
     return (
         <div className={styles.copy} title={value}>
             {label && label}
-            <CopyToClipboard text={value} onCopy={() => setCopied(true)}>
-                <span className={styles.copyIcon}>
+                <span className={styles.copyIcon} onClick={() => {
+                    navigator.clipboard.writeText(value)
+                    setCopied(true)
+                }}>
                     {copied ? <CheckmarkIcon /> : <CopyIcon />}
                 </span>
-            </CopyToClipboard>
         </div>
     )
 }

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 .nav {
     display: flex;
@@ -9,7 +9,7 @@
     padding: 0 16px;
     max-width: 1920px;
     width: 100%;
-    @include tablet {
+    @include mixins.tablet {
         padding: 0 64px;
     }
 }

--- a/src/components/RollupSummaryCard/styles.module.scss
+++ b/src/components/RollupSummaryCard/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 .card {
     display: flex;
@@ -8,11 +8,11 @@
     border: 1px solid var( --border-color);
     background: var(--background);
     position: relative;
-    @include tablet {
+    @include mixins.tablet {
         flex: 1 1 48.5%;
         max-width: 49.5%;
     }
-    @include desktop {
+    @include mixins.desktop {
         flex: 1 1 31.5%;
         max-width: 32.5%;
     }

--- a/src/pages/[slug]/index.tsx
+++ b/src/pages/[slug]/index.tsx
@@ -8,7 +8,6 @@ import matter from 'gray-matter'
 import { serialize } from 'next-mdx-remote/serialize'
 import styles from './styles.module.scss'
 import { MDXRemote } from 'next-mdx-remote'
-import { Params } from 'next/dist/shared/lib/router/utils/route-matcher'
 import MDXShortcodes from '@components/MDXShortcodes'
 import remarkGfm from 'remark-gfm'
 import DropdownLinks from '@components/DropdownLinks'
@@ -206,7 +205,7 @@ export async function getStaticPaths(): Promise<StaticPathsResult> {
 
 export async function getStaticProps({
     params,
-}: Params): Promise<StaticPropsResult> {
+}: Path): Promise<StaticPropsResult> {
     const { slug } = params
 
     const contents = await getDocsContent()

--- a/src/pages/[slug]/styles.module.scss
+++ b/src/pages/[slug]/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 .hero {
     display: flex;
@@ -19,7 +19,7 @@
     padding-bottom: 40px;
     display: flex;
     flex-direction: column;
-    @include desktop {
+    @include mixins.desktop {
         margin-left: 64px;
     }
 }
@@ -27,14 +27,14 @@
 .pageGrid {
     display: flex;
     flex-direction: column;
-    @include desktop {
+    @include mixins.desktop {
         flex-direction: row;
     }
 }
 
 .sidebar {
     display: none;
-    @include desktop {
+    @include mixins.desktop {
         max-width: 100%;
         width: 100%;
         display: flex;
@@ -48,7 +48,7 @@
 
 .sidebar_placeholder {
     display: none;
-    @include tablet {
+    @include mixins.tablet {
         display: block;
         width: 270px;
     }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,4 +1,4 @@
-@import '@styles/mixins.scss';
+@use '@styles/mixins';
 
 :root {
     --neutral100: #000000;


### PR DESCRIPTION
- Updates `Next` to `15.2.1`
- Updates `React` to `19.0.0`
- Updates `sass` to `1.85.1`
- Removes `react-copy-to-clipboard` since it's not compatible with React 19
- Updates all other dependencies to latest version
- Replaces the deprecated `@import` in `sass` with `@use`