### PR TITLE
feat(linea): Update opcodes

### DIFF
--- a/src/docs/linea.mdx
+++ b/src/docs/linea.mdx
@@ -120,9 +120,7 @@ Linea is a ZK-Rollup that targets EVM compatibility. As it’s a product of Cons
     | 5D | TSTORE | `tstore(key, value)` | Unsupported. If the opcode is encountered, the transaction will be reverted. | Saves the value at the given address in the transient storage.  <Unsupported /> |
     | 5E | MCOPY | `mcopy()` | Unsupported. If the opcode is encountered, the transaction will be reverted. | Copies the memory from source to destination.  <Unsupported /> |
     | 5F | PUSH0 |  | Not supported yet! <br /><br /> Solidity version `0.8.20` or higher can only be used with an evm version lower than the default `shanghai`. <br /><br /> Versions up to `0.8.19` (included) are fully compatible | Places value 0 on the stack <Unsupported /> |
-    | 42 | TIMESTAMP | `block.timestamp` | Timestamp of the L2 block | Timestamp of the L1 block <Modified /> |
-    | 43 | NUMBER | `block.number` | L2 block number | Gets the L1 block number <Modified /> |
-    | 44 | PREVRANDAO (legacy DIFFICULTY) | `block.difficulty` | Returns a fixed number "2" | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
+    | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns a fixed number "2" | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
 
 </Section>
 


### PR DESCRIPTION
Marks `TIMESTAMP` and `NUMBER` as supported opcodes