### PR TITLE
feat(opstack): Update opcodes

### DIFF
--- a/src/docs/base.mdx
+++ b/src/docs/base.mdx
@@ -105,11 +105,9 @@ links:
 
     | Opcode | Name | Solidity Equivalent | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :--- | :-------------------| :--------------- | :-------------------- |
-    | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
     | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the randomness beacon provided by the L1 beacon chain of the latest synced L1 state on the L2 | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
-    | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>
 

--- a/src/docs/blast.mdx
+++ b/src/docs/blast.mdx
@@ -104,11 +104,9 @@ links:
 
     | Opcode | Name | Solidity Equivalent | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :--- | :-------------------| :--------------- | :-------------------- |
-    | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
     | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the randomness beacon provided by the L1 beacon chain of the latest synced L1 state on the L2 | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
-    | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>
 

--- a/src/docs/optimism.mdx
+++ b/src/docs/optimism.mdx
@@ -104,11 +104,9 @@ links:
 
     | Opcode | Name | Solidity Equivalent | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :--- | :-------------------| :--------------- | :-------------------- |
-    | 49 | BLOBHASH | `blobhash(index)` | Undefined | Returns versioned hash of the `index`-th blob associated with the current transaction. <Unsupported /> |
     | 32 | ORIGIN | `tx.origin` | The opcodes has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case `tx.origin` is set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get the execution origination address <Modified /> |
     | 33 | CALLER | `msg.sender` | The opcode has the same behaviour as in Ethereum L1 except for situations in which the transaction is an L1 to L2 transaction. <br /><br /> In that case, the top-level contract to be called on L2 has `msg.sender` set to the [aliased address](https://community.optimism.io/docs/developers/build/differences/#address-aliasing) of the address that triggered the transaction. | Get caller address <Modified /> |
     | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the randomness beacon provided by the L1 beacon chain of the latest synced L1 state on the L2 | Get the output of the randomness beacon provided by the beacon chain <Modified /> |
-    | 4A | BLOBBASEFEE | `block.blobbasefee` | Always returns 1 | Returns current block’s blob base fee. <Modified /> |
 
 </Section>
 


### PR DESCRIPTION
Marks `BLOBHASH` and `BLOBBASFEE` as supported opcodes