### PR TITLE
feat(arbitrum): Update coinbase opcode

### DIFF
--- a/src/docs/arbitrum-one.mdx
+++ b/src/docs/arbitrum-one.mdx
@@ -114,7 +114,7 @@ links:
     | 4A | BLOBBASEFEE | `block.blobbasefee` | Unsupported. If the opcode is encountered, the transaction will be reverted. | Returns current block’s blob base fee.  <Unsupported /> |
     | 33 | CALLER | `msg.sender` | Same behaviour as on Ethereum for L2 to L2 transactions <br /><br /> Returns the L2 address alias of the L1 contract that triggered the message for L1-to-L2 "retryable ticket" transactions. See [retryable ticket address aliasing](https://developer.arbitrum.io/arbos/l1-to-l2-messaging#address-aliasing) for more. | Returns caller address <Modified /> |
     | 40 | BLOCKHASH | `blockhash(x)` | Returns a cryptographically insecure, pseudo-random hash for `x` within the range `block.number - 256 <= x < block.number`. <br /><br /> If `x` is outside of this range, `blockhash(x)` will return 0. This includes `blockhash(block.number)`, which always returns `0` just like on Ethereum. <br /><br /> The hashes returned do not come from L1. | Returns the hash of one of the 256 most recent complete blocks <Modified /> |
-    | 41 | COINBASE | `block.coinbase` | Returns `0` | Returns the L1 block’s beneficiary address <Modified /> |
+    | 41 | COINBASE | `block.coinbase` | Returns the designated internal address `0xA4b000000000000000000073657175656e636572` if the message was posted by a sequencer. If it's a delayed message, it returns the address of the delayed message's poster | Returns the L1 block’s beneficiary address <Modified /> |
     | 43 | NUMBER | `block.number` | Returns an "estimate" of the L1 block number at which the Sequencer received the transaction (see [Block Numbers and Time](https://developer.arbitrum.io/time)) | Returns the L1 block number <Modified /> |
     | 44 | PREVRANDAO | `block.difficulty` and `block.prevrandao` | Returns the constant `1` | Returns the output of the randomness beacon provided by the beacon chain <Modified /> |
 
@@ -122,7 +122,13 @@ links:
 
 <Section title="Precompiled Contracts">
 
-    All Precompiled Contracts defined in the canonical Ethereum L1 implementation have the same behaviour on the Rollup.
+    <Legend />
+
+    The following Precompiled Contracts behave differently compared to the canonical Ethereum L1
+
+    | Address | Name | Rollup Behaviour | Ethereum L1 Behaviour |
+    | :----- | :----- | :--------------- | :-------------------- |
+    | <Copy label="0x100" value="0x100" /> | `p256Verify` | Performs signature verifications in the secp256r1 elliptic curve | Not supported <Added /> |
 
 </Section>
 
@@ -141,7 +147,6 @@ links:
     | <Copy value="0x64" label="0x64" /> | <Reference label="ArbSys" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbSys.go" /> | Provides system-level functionality for getting L2 block number, hash, checking if a call is top-level, sending cross-domain messages as-well as sending ETH to L1.| N/A <Added /> |
     | <Copy value="0x65" label="0x65" /> | <Reference label="ArbInfo" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbInfo.go" /> | Provides the ability to lookup account's balance and contract's deployed code.| N/A <Added /> |
     | <Copy value="0x6b" label="0x6b" /> | <Reference label="ArbOwnerPublic" url="https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbOwnerPublic.go" /> | Provides non-owners with info about the current chain owners.| N/A <Added /> |
-    | <Copy label="0x100" value="0x100" /> | `p256Verify` | Performs signature verifications in the secp256r1 elliptic curve | Not supported <Added /> |
 
 </Section>
 


### PR DESCRIPTION
- Updates the description of `COINBASE` opcode. [source](https://docs.arbitrum.io/build-decentralized-apps/arbitrum-vs-ethereum/solidity-support#differences-from-solidity-on-ethereum)
- Moves the `p256Verify` precompile from the "System contracts" table to the correct, "Precompiled contracts" table