### PR TITLE
feat(opstack): update RPC-API

### DIFF
--- a/src/docs/base.mdx
+++ b/src/docs/base.mdx
@@ -1,6 +1,6 @@
 ---
 title: Base
-subtitle: Base is an Optimistic Rollup utilizing the OP Stack technology. The protocol features a centralised sequencer operated by the Base team. Fraud proofs have yet to be enabled on the platform.
+subtitle: Base is an Optimistic Rollup utilizing the OP Stack technology. The protocol features a centralised sequencer operated by the Base team.
 labels:
     - Optimistic Rollup
     - EVM
@@ -157,7 +157,9 @@ links:
 
     | Method | Params | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :----- | :--------------- | :-------------------- |
-    | `eth_newPendingTransactionFilter` | None | Not supported  | Creates a filter in the node to notify when new pending transactions arrive. <Unsupported /> |
+    | `eth_getTransactionReceipt` | `hash` | Returns information for a given transaction. <br /><br />Adds additional information related to L1 calldata fees. | Returns information for a given transaction. <Modified /> |
+    | `optimism_outputAtBlock` | Integer block number or string one of `safe`, `latest` or `pending` | Returns the requested `l2OutputRoot` containing `version` and `l2OutputRoot` | N/A <Added /> |
+    | `optimism_syncStatus` | None | Returns information on node’s current, head, safe and finalised L1 state, as well as unsafe, safe and finalized L2 state | N/A <Added /> |
 
 </Section>
 

--- a/src/docs/base.mdx
+++ b/src/docs/base.mdx
@@ -39,9 +39,9 @@ links:
 
     <Parameter name="Block time" value="2 seconds" tooltip="The rate at which the rollup produces blocks. Keep in mind that the value is subject to change in the future" />
 
-    <Parameter name="Gas Limit" value="30 million" tooltip="The gas limit that can be consumed by an L2 block" />
+    <Parameter name="Gas Limit" value="120 million" tooltip="The gas limit that can be consumed by an L2 block" />
 
-    <Parameter name="Gas Target" value="15 million" tooltip="The EIP-1559 gas target for an L2 block" />
+    <Parameter name="Gas Target" value="60 million" tooltip="The EIP-1559 gas target for an L2 block" />
 
     <Parameter name="Sequencing Frequency" value="~1 minute" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. The time varies based on the amount of calldata that must be posted on L1" />
 

--- a/src/docs/blast.mdx
+++ b/src/docs/blast.mdx
@@ -151,11 +151,7 @@ links:
 
     | Method | Params | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :----- | :--------------- | :-------------------- |
-    | `eth_newPendingTransactionFilter` | None | Not supported  | Creates a filter in the node to notify when new pending transactions arrive. <Unsupported /> |
-    | `eth_getBlockByNumber` | Integer block number or string one of `safe`, `latest` or `pending` | Returns information for a given block.<br /><br />Adds additional information for transactions such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given block. <Modified /> |
-    | `eth_getBlockByHash` | hash | Returns information for a given block.<br /><br />Adds additional information for transactions such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given block. <Modified /> |
-    | `eth_getTransactionByHash` | hash | Returns information for a given transaction. <br /><br />Adds additional information such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given transaction. <Modified /> |
-    | `eth_getTransactionReceipt` | hash | Returns information for a given transaction. <br /><br />Adds additional information related to L1 calldata fees. | Returns information for a given transaction. <Modified /> |
+    | `eth_getTransactionReceipt` | `hash` | Returns information for a given transaction. <br /><br />Adds additional information related to L1 calldata fees. | Returns information for a given transaction. <Modified /> |
     | `optimism_outputAtBlock` | Integer block number or string one of `safe`, `latest` or `pending` | Returns the requested `l2OutputRoot` containing `version` and `l2OutputRoot` | N/A <Added /> |
     | `optimism_syncStatus` | None | Returns information on node’s current, head, safe and finalised L1 state, as well as unsafe, safe and finalized L2 state | N/A <Added /> |
 

--- a/src/docs/ink.mdx
+++ b/src/docs/ink.mdx
@@ -42,7 +42,7 @@ links:
 
     <Parameter name="Gas Limit" value="30 million" tooltip="The gas limit that can be consumed by an L2 block" />
 
-    <Parameter name="Gas Target" value="15 million" tooltip="The EIP-1559 gas target for an L2 block" />
+    <Parameter name="Gas Target" value="5 million" tooltip="The EIP-1559 gas target for an L2 block" />
 
     <Parameter name="Sequencing Frequency" value="10-60 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. The time varies based on the amount of calldata that must be posted on L1" />
 

--- a/src/docs/ink.mdx
+++ b/src/docs/ink.mdx
@@ -117,11 +117,7 @@ links:
 
     | Method | Params | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :----- | :--------------- | :-------------------- |
-    | `eth_newPendingTransactionFilter` | None | Not supported  | Creates a filter in the node to notify when new pending transactions arrive. <Unsupported /> |
-    | `eth_getBlockByNumber` | Integer block number or string one of `safe`, `latest` or `pending` | Returns information for a given block.<br /><br />Adds additional information for transactions such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given block. <Modified /> |
-    | `eth_getBlockByHash` | hash | Returns information for a given block.<br /><br />Adds additional information for transactions such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given block. <Modified /> |
-    | `eth_getTransactionByHash` | hash | Returns information for a given transaction. <br /><br />Adds additional information such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given transaction. <Modified /> |
-    | `eth_getTransactionReceipt` | hash | Returns information for a given transaction. <br /><br />Adds additional information related to L1 calldata fees. | Returns information for a given transaction. <Modified /> |
+    | `eth_getTransactionReceipt` | `hash` | Returns information for a given transaction. <br /><br />Adds additional information related to L1 calldata fees. | Returns information for a given transaction. <Modified /> |
     | `optimism_outputAtBlock` | Integer block number or string one of `safe`, `latest` or `pending` | Returns the requested `l2OutputRoot` containing `version` and `l2OutputRoot` | N/A <Added /> |
     | `optimism_syncStatus` | None | Returns information on node’s current, head, safe and finalised L1 state, as well as unsafe, safe and finalized L2 state | N/A <Added /> |
 

--- a/src/docs/optimism.mdx
+++ b/src/docs/optimism.mdx
@@ -157,11 +157,7 @@ links:
 
     | Method | Params | Rollup Behaviour | Ethereum L1 Behaviour |
     | :----- | :----- | :--------------- | :-------------------- |
-    | `eth_newPendingTransactionFilter` | None | Not supported  | Creates a filter in the node to notify when new pending transactions arrive. <Unsupported /> |
-    | `eth_getBlockByNumber` | Integer block number or string one of `safe`, `latest` or `pending` | Returns information for a given block.<br /><br />Adds additional information for transactions such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given block. <Modified /> |
-    | `eth_getBlockByHash` | hash | Returns information for a given block.<br /><br />Adds additional information for transactions such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given block. <Modified /> |
-    | `eth_getTransactionByHash` | hash | Returns information for a given transaction. <br /><br />Adds additional information such as l1 block number, l1 timestamp, queue origin and raw transaction. | Returns information for a given transaction. <Modified /> |
-    | `eth_getTransactionReceipt` | hash | Returns information for a given transaction. <br /><br />Adds additional information related to L1 calldata fees. | Returns information for a given transaction. <Modified /> |
+    | `eth_getTransactionReceipt` | `hash` | Returns information for a given transaction. <br /><br />Adds additional information related to L1 calldata fees. | Returns information for a given transaction. <Modified /> |
     | `optimism_outputAtBlock` | Integer block number or string one of `safe`, `latest` or `pending` | Returns the requested `l2OutputRoot` containing `version` and `l2OutputRoot` | N/A <Added /> |
     | `optimism_syncStatus` | None | Returns information on node’s current, head, safe and finalised L1 state, as well as unsafe, safe and finalized L2 state | N/A <Added /> |
 

--- a/src/docs/optimism.mdx
+++ b/src/docs/optimism.mdx
@@ -39,9 +39,9 @@ links:
 
     <Parameter name="Block time" value="2 seconds" tooltip="The rate at which the rollup produces blocks. Keep in mind that the value is subject to change in the future" />
 
-    <Parameter name="Gas Limit" value="30 million" tooltip="The gas limit that can be consumed by an L2 block" />
+    <Parameter name="Gas Limit" value="60 million" tooltip="The gas limit that can be consumed by an L2 block" />
 
-    <Parameter name="Gas Target" value="15 million" tooltip="The EIP-1559 gas target for an L2 block" />
+    <Parameter name="Gas Target" value="30 million" tooltip="The EIP-1559 gas target for an L2 block" />
 
     <Parameter name="Sequencing Frequency" value="~6 minutes" tooltip="The frequency at which the rollup posts L2 transactions on Ethereum L1. The time varies based on the amount of calldata that must be posted on L1" />
 


### PR DESCRIPTION
- `eth_getBlockByNumber`, `eth_getTransactionByHash` and `eth_getTransactionReceipt` RPC calls are the same as on ETH
- `eth_newPendingTransactionFilter` is supported by `op-geth`