### PR TITLE
feat: support multiple execution environments of one network

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "chain-specs"]
 	path = chain-specs
 	url = https://github.com/LimeChain/chain-specs
-	branch = feat(zk-stack)/evm-execution-environment
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "chain-specs"]
 	path = chain-specs
 	url = https://github.com/LimeChain/chain-specs
-	branch = main
+	branch = feat(zk-stack)/evm-execution-environment

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -12,11 +12,12 @@ import LinkIcon from '/public/images/link-icon.svg'
 
 interface ISection {
     title: string
+    initialExpanded: boolean
     children: React.ReactNode
 }
 
-const Section = ({ title, children }: ISection) => {
-    const [isExpanded, setExpanded] = useState<boolean>(true)
+const Section = ({ title, initialExpanded=true, children }: ISection) => {
+    const [isExpanded, setExpanded] = useState<boolean>(initialExpanded)
     const { theme } = useTheme()
     const ref = useRef<any>(0)
 

--- a/src/docs/abstract.mdx
+++ b/src/docs/abstract.mdx
@@ -94,8 +94,8 @@ links:
 
 </Section>
 
-> ⚠️ Contracts on ZKsync Era can be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode using the EVM Bytecode Emulator.
-> Native EraVM bytecode offers better performance and lower fees versus unmodified contracts compiled with standard Solidity or Vyper and interpreted during execution.
+> ⚠️ Contracts on ZKsync Era can be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) / [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode using the EVM Bytecode Emulator.
+> Native EraVM bytecode offers better performance and lower fees versus unmodified contracts compiled with standard Solidity or Vyper which are interpreted during execution.
 
 <Section title="OPCODEs (custom compiler)" initialExpanded={false}>
     > ⚠️ OPCODE differences when using a custom compiler (`zksolc` or `zkvyper`)

--- a/src/docs/abstract.mdx
+++ b/src/docs/abstract.mdx
@@ -95,7 +95,7 @@ links:
 </Section>
 
 > ⚠️ Contracts on ZKsync Era can be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode using the EVM Bytecode Emulator.
-> While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
+> Native EraVM bytecode offers better performance and lower fees versus unmodified contracts compiled with standard Solidity or Vyper and interpreted during execution.
 
 <Section title="OPCODEs (custom compiler)" initialExpanded={false}>
     > ⚠️ OPCODE differences when using a custom compiler (`zksolc` or `zkvyper`)

--- a/src/docs/abstract.mdx
+++ b/src/docs/abstract.mdx
@@ -94,7 +94,7 @@ links:
 
 </Section>
 
-> ⚠️ Contracts on ZKsync Era can now be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode, thanks to the EVM Bytecode Emulator.
+> ⚠️ Contracts on ZKsync Era can be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode using the EVM Bytecode Emulator.
 > While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
 
 <Section title="OPCODEs (custom compiler)" initialExpanded={false}>

--- a/src/docs/abstract.mdx
+++ b/src/docs/abstract.mdx
@@ -94,16 +94,27 @@ links:
 
 </Section>
 
-<Section title="OPCODEs">
-    <Table data={opcodes} type="opcodes" />
+> ⚠️ Contracts on ZKsync Era can now be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode, thanks to the EVM Bytecode Emulator.
+> While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
+
+<Section title="OPCODEs (custom compiler)" initialExpanded={false}>
+    > ⚠️ OPCODE differences when using a custom compiler (`zksolc` or `zkvyper`)
+
+    <Table data={eravm.opcodes} type="opcodes" />
+</Section>
+
+<Section title="OPCODEs (standard compiler)" initialExpanded={false}>
+    > ⚠️ OPCODE differences when using a standard compiler (`solc` or `vyper`)
+
+    <Table data={evm.opcodes} executionEnv="evm" type="opcodes" />
 </Section>
 
 <Section title="Precompiled Contracts">
-    <Table data={precompiles} type="precompiles" />
+    <Table data={eravm.precompiles} type="precompiles" />
 </Section>
 
 <Section title="System Contracts">
-    <Table data={system_contracts} type="system_contracts" />
+    <Table data={eravm.system_contracts} type="system_contracts" />
 </Section>
 
 <Section title="RPC-API">

--- a/src/docs/zksync-era.mdx
+++ b/src/docs/zksync-era.mdx
@@ -94,8 +94,8 @@ links:
 
 </Section>
 
-> ⚠️ Contracts on ZKsync Era can be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode using the EVM Bytecode Emulator.
-> Native EraVM bytecode offers better performance and lower fees versus unmodified contracts compiled with standard Solidity or Vyper and interpreted during execution.
+> ⚠️ Contracts on ZKsync Era can be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) / [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode using the EVM Bytecode Emulator.
+> Native EraVM bytecode offers better performance and lower fees versus unmodified contracts compiled with standard Solidity or Vyper which are interpreted during execution.
 
 <Section title="OPCODEs (custom compiler)" initialExpanded={false}>
     > ⚠️ OPCODE differences when using a custom compiler (`zksolc` or `zkvyper`)

--- a/src/docs/zksync-era.mdx
+++ b/src/docs/zksync-era.mdx
@@ -94,8 +94,8 @@ links:
 
 </Section>
 
-> ⚠️ Contracts on ZKsync Era can now be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode, thanks to the EVM Bytecode Emulator.
-> While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
+> ⚠️ Contracts on ZKsync Era can be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode using the EVM Bytecode Emulator.
+> Native EraVM bytecode offers better performance and lower fees versus unmodified contracts compiled with standard Solidity or Vyper and interpreted during execution.
 
 <Section title="OPCODEs (custom compiler)" initialExpanded={false}>
     > ⚠️ OPCODE differences when using a custom compiler (`zksolc` or `zkvyper`)

--- a/src/docs/zksync-era.mdx
+++ b/src/docs/zksync-era.mdx
@@ -94,16 +94,17 @@ links:
 
 </Section>
 
-<Section title="OPCODEs (compiler)" initialExpanded={false}>
-    > ⚠️ Contracts on ZKsync Era can now be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode, thanks to the EVM Bytecode Emulator.
-    > While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
+> ⚠️ Contracts on ZKsync Era can now be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode, thanks to the EVM Bytecode Emulator.
+> While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
+
+<Section title="OPCODEs (custom compiler)" initialExpanded={false}>
+    > ⚠️ OPCODE differences when using a custom compiler (`zksolc` or `zkvyper`)
 
     <Table data={eravm.opcodes} type="opcodes" />
 </Section>
 
-<Section title="OPCODEs (interpreter)" initialExpanded={false}>
-    > ⚠️ Contracts on ZKsync Era can now be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode, thanks to the EVM Bytecode Emulator.
-    > While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
+<Section title="OPCODEs (standard compiler)" initialExpanded={false}>
+    > ⚠️ OPCODE differences when using a standard compiler (`solc` or `vyper`)
 
     <Table data={evm.opcodes} executionEnv="evm" type="opcodes" />
 </Section>

--- a/src/docs/zksync-era.mdx
+++ b/src/docs/zksync-era.mdx
@@ -94,19 +94,26 @@ links:
 
 </Section>
 
-<Section title="OPCODEs">
+<Section title="OPCODEs (compiler)" initialExpanded={false}>
     > ⚠️ Contracts on ZKsync Era can now be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode, thanks to the EVM Bytecode Emulator.
     > While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
 
-    <Table data={opcodes} type="opcodes" />
+    <Table data={eravm.opcodes} type="opcodes" />
+</Section>
+
+<Section title="OPCODEs (interpreter)" initialExpanded={false}>
+    > ⚠️ Contracts on ZKsync Era can now be deployed using either the custom compiler ([zksolc](https://github.com/matter-labs/zksolc-bin) or [zkvyper](https://github.com/matter-labs/zkvyper-bin)) **or** standard EVM bytecode, thanks to the EVM Bytecode Emulator.
+    > While native EraVM bytecode offers better performance and lower fees, developers can now deploy unmodified contracts compiled with standard Solidity or Vyper.
+
+    <Table data={evm.opcodes} executionEnv="evm" type="opcodes" />
 </Section>
 
 <Section title="Precompiled Contracts">
-    <Table data={precompiles} type="precompiles" />
+    <Table data={eravm.precompiles} type="precompiles" />
 </Section>
 
 <Section title="System Contracts">
-    <Table data={system_contracts} type="system_contracts" />
+    <Table data={eravm.system_contracts} type="system_contracts" />
 </Section>
 
 <Section title="RPC-API">

--- a/src/pages/[slug]/index.tsx
+++ b/src/pages/[slug]/index.tsx
@@ -165,8 +165,11 @@ const getChainSpecs = (network: string): ExecutionEnvironmentsMap => {
 
         files.forEach(file => {
             const fileContents = fs.readFileSync(`${folder}${file}`, 'utf8')
-            const executionEnvironment = file.split('.')[0].split('|')[1] || "evm"
             const chainSpec = JSON.parse(fileContents)
+
+            // Chainspec files are named <network>[_<execEnv>].json
+            // Set the environment to "evm" if it isn't specified
+            const executionEnvironment = file.split('.')[0].split('_')[1] || "evm"
 
             const customChainSpec: CustomChainSpec = {
                 opcodes: {},

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -109,6 +109,10 @@ export interface ICrumb {
 
 export type Breadcrumbs = ICrumb[]
 
+export type ExecutionEnvironmentsMap = {
+    [env: string]: CustomChainSpec
+}
+
 export type CustomChainSpec = {
     opcodes: ChainSpecElementsMap,
     precompiles: ChainSpecElementsMap,


### PR DESCRIPTION
Adds support for multiple exectution environments of one network. If there is only one chain specification for a network, we assume it is an EVM execution environment. Otherwise we use the last part of the file name to determine the exec env.

Example:
`arbitrum-one.json` => only one chain spec for Arbitrum, it is an EVM chain spec

`[ zk-sync-era_evm.json, zk-sync-era_eravm.json]` => 2 chain specs, one for EVM and one for EraVM